### PR TITLE
Update CMake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(ILR)
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   # Allow standalone builds


### PR DESCRIPTION
There is a warning in some newer versions of <3.5 support being deprecated. 3.5 is not an unreasonable version to assume.