### PR TITLE
Rename 'vector' type to 'scaled'

### DIFF
--- a/code/include/ilr/type.h
+++ b/code/include/ilr/type.h
@@ -29,9 +29,10 @@ enum ilr_type {
   ilr_pointer,
   /// Array of values, takes two parameters: length, and element type
   ilr_array,
-  /// Vector, takes two parameters: length (# elements) and lane type
-  /// intended for performing the same operation on all lanes
-  ilr_vector,
+  /// Fixed-width scaled (vector) type, takes two parameters: length (number of
+  /// elements) and lane type / intended for performing the same operation on all
+  /// lanes
+  ilr_scaled,
   /// C-style structure, parameters: number of fields, followed by types of the fields
   ilr_struct,
   /// Function, parameters: return type, number of aguments, types of arguments
@@ -67,13 +68,13 @@ ilr_value_type_t * ilr_type_pointer(ilr_value_type_t * element_type);
 /// FIXME ammount of size to support
 ilr_value_type_t * ilr_type_array(unsigned short size, ilr_value_type_t * element_type);
 
-/// Create vector type
+/// Create scaled type
 ///
 /// \param size number of lanes
 /// \param element_type type of each lane
 ///
 /// Vectors support only 16 bits of size
-ilr_value_type_t * ilr_type_vector(unsigned short size, ilr_value_type_t * element_type);
+ilr_value_type_t * ilr_type_scaled(unsigned short size, ilr_value_type_t * element_type);
 
 /// Create structure type
 ///
@@ -108,11 +109,11 @@ unsigned short ilr_get_array_size(ilr_value_type_t * arr_type);
 /// Get array element type
 ilr_value_type_t * ilr_get_array_element_type(ilr_value_type_t * t);
 
-/// Get vector size
-unsigned short ilr_get_vector_size(ilr_value_type_t * vec_type);
+/// Get scaled size
+unsigned short ilr_get_scaled_size(ilr_value_type_t * vec_type);
 
-/// Get vector lane type
-ilr_value_type_t * ilr_get_vector_lane_type(ilr_value_type_t * t);
+/// Get scaled lane type
+ilr_value_type_t * ilr_get_scaled_lane_type(ilr_value_type_t * t);
 
 /// Get number of fields in a structure type
 unsigned short ilr_get_struct_size(ilr_value_type_t * t);

--- a/code/src/type.c
+++ b/code/src/type.c
@@ -21,7 +21,7 @@ unsigned ilr_type_get_unboxed_size(ilr_element_t * tarr, unsigned tarr_size) {
       assert(tarr_size > 1);
       return (ilr_type_get_unboxed_size(tarr + 1, tarr_size - 1) + 1);
     case ilr_array:
-    case ilr_vector:
+    case ilr_scaled:
       assert(tarr_size > 2);
       return (ilr_type_get_unboxed_size(tarr + 2, tarr_size - 2) + 2);
     case ilr_struct:
@@ -114,9 +114,9 @@ ilr_value_type_t * ilr_type_array(unsigned short size, ilr_value_type_t * elemen
   return t;
 }
 
-ilr_value_type_t * ilr_type_vector(unsigned short size, ilr_value_type_t * element_type) {
+ilr_value_type_t * ilr_type_scaled(unsigned short size, ilr_value_type_t * element_type) {
   // Allocate enough space to store entire pointee type
-  ilr_value_type_t * t = ilr_type_init(ilr_vector, element_type->size + 2);
+  ilr_value_type_t * t = ilr_type_init(ilr_scaled, element_type->size + 2);
   // Set size
   t->type[1] = size;
   // Copy element type
@@ -203,13 +203,13 @@ ilr_value_type_t * ilr_get_array_element_type(ilr_value_type_t * t) {
   return elem;
 }
 
-unsigned short ilr_get_vector_size(ilr_value_type_t * vec_type) {
-  assert(vec_type->type[0] == ilr_vector);
+unsigned short ilr_get_scaled_size(ilr_value_type_t * vec_type) {
+  assert(vec_type->type[0] == ilr_scaled);
   return vec_type->type[1];
 }
 
-ilr_value_type_t * ilr_get_vector_lane_type(ilr_value_type_t * t) {
-  assert(t->type[0] == ilr_vector);
+ilr_value_type_t * ilr_get_scaled_lane_type(ilr_value_type_t * t) {
+  assert(t->type[0] == ilr_scaled);
   ilr_value_type_t * elem = ilr_type_init(t->type[2], t->size - 2);
   memcpy(&(elem->type[1]), &(t->type[3]), sizeof(ilr_element_t) * (elem->size - 1));
   return elem;

--- a/code/test/types.c
+++ b/code/test/types.c
@@ -65,9 +65,9 @@ int main(void) {
   CHECK(p_entry == NULL);
 
   p_entry = ilr_type_double();
-  p = ilr_type_vector(4, p_entry);
+  p = ilr_type_scaled(4, p_entry);
   CHECK(p->size == p_entry->size + 2);
-  CHECK(p->type[0] == ilr_vector);
+  CHECK(p->type[0] == ilr_scaled);
   CHECK(p->type[1] == 4);
   for (i = 0; i < p_entry->size; ++i) {
     CHECK(p->type[i + 2] == p_entry->type[i]);
@@ -159,13 +159,13 @@ int main(void) {
   ilr_type_free(&p_entry);
   CHECK(p_entry == NULL);
 
-  t.type[0] = ilr_vector;
+  t.type[0] = ilr_scaled;
   t.type[1] = 4;
   t.type[2] = ilr_float;
   CHECK(ilr_type_get_unboxed_size(t.type, t.size) == t.size);
-  CHECK(ilr_type_is(&t) == ilr_vector);
-  CHECK(ilr_get_vector_size(&t) == 4);
-  p_entry = ilr_get_vector_lane_type(&t);
+  CHECK(ilr_type_is(&t) == ilr_scaled);
+  CHECK(ilr_get_scaled_size(&t) == 4);
+  p_entry = ilr_get_scaled_lane_type(&t);
   CHECK(ilr_type_is(p_entry) == ilr_float);
   ilr_type_free(&p_entry);
   CHECK(p_entry == NULL);


### PR DESCRIPTION
Reserve 'vector' for a potential length-agnostic type, rename fixed-length type to 'scaled'.